### PR TITLE
[FEATURE] Add filedate to VCF file

### DIFF
--- a/include/bio/var_io/header.hpp
+++ b/include/bio/var_io/header.hpp
@@ -13,6 +13,9 @@
 
 #pragma once
 
+#include <chrono>
+#include <ctime>
+#include <iomanip>
 #include <map>
 #include <regex>
 #include <string>
@@ -163,6 +166,7 @@ public:
      * \{
      */
     std::string              file_format = "VCFv4.3"; //!< The file format version.
+    std::string              file_date = transTime(); //!< The file date.
     std::vector<filter_t>    filters;                 //!< Header lines describing FILTER fields.
     std::vector<info_t>      infos;                   //!< Header lines describing INFO fields.
     std::vector<format_t>    formats;                 //!< Header lines describing FORMAT fields.
@@ -214,6 +218,19 @@ public:
     /*!\name Update, reset and inspect
      * \{
      */
+    /*! \brief Gets the current time and transforms it in a nice readable way for the vcf header line fileDate.
+     *
+     * \returns a time string in the format: YYYY-MM-DD HH:MM:SS.
+     */
+    std::string transTime()
+    {
+        std::stringstream text_stream;
+        const std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+        const std::time_t rawtime = std::chrono::system_clock::to_time_t(now);
+        text_stream << std::put_time(std::localtime(&rawtime), "%F %T");
+        std::string time_string = text_stream.str();
+        return time_string;
+    }
     /*!\brief Add missing IDX fields to header entries and ensure that everything has proper hash-entries.
      *
      * \details
@@ -478,6 +495,9 @@ private:
         // file format
         ((raw_data += "##fileformat=") += file_format) += "\n";
 
+        // file date
+        ((raw_data += "##fileDate=") += file_date) += "\n";
+
         // filters
         for (auto const & filter : filters)
         {
@@ -611,6 +631,10 @@ private:
         {
             throw format_error{"File has two lines that begin with \"##fileformat\"."};
         }
+        else if (l.starts_with("##fileDate="))
+        {
+            parse_file_date_line(l.substr(11));
+        }
         else if (l.starts_with("##INFO="))
         {
             parse_info_or_format_line(strip_angular_brackets(l.substr(7)), true);
@@ -639,6 +663,12 @@ private:
         {
             throw format_error{"Plaintext header contains lines that don't start with \"##\" or \"#CHROM\"."};
         }
+    }
+
+    //!\brief Parse an INFO or FORMAT line.
+    void parse_file_date_line(std::string_view const l)
+    {
+        file_date = static_cast<std::string>(l);
     }
 
     //!\brief Parse an INFO or FORMAT line.

--- a/test/snippet/var_io/var_io_writer.cpp
+++ b/test/snippet/var_io/var_io_writer.cpp
@@ -18,6 +18,7 @@ using namespace seqan3::literals;
 // a plaintext header
 std::string_view const text_header =
 R"(##fileformat=VCFv4.3
+##fileDate=2022-03-02 14:18:22
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
@@ -92,6 +93,7 @@ bio::var_io::writer writer{"example2.vcf",
 // add header so destructor works
 std::string_view const text_header =
 R"(##fileformat=VCFv4.3
+##fileDate=2022-03-02 14:18:22
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
 )";
 writer.set_header(bio::var_io::header{text_header});

--- a/test/unit/format/bcf_data.hpp
+++ b/test/unit/format/bcf_data.hpp
@@ -184,8 +184,8 @@ inline constexpr std::string_view example_from_spec_bcf_unbgzf_our{
 
 inline constexpr std::string_view example_from_spec_bcf_header =
   R"(##fileformat=VCFv4.3
+##fileDate=2022-03-02 14:18:22
 ##FILTER=<ID=PASS,Description="All filters passed",IDX=0>
-##fileDate=20090805
 ##source=myImputationProgramV3.1
 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x,IDX=0>

--- a/test/unit/format/vcf_data.hpp
+++ b/test/unit/format/vcf_data.hpp
@@ -31,7 +31,7 @@ inline std::string const example_from_spec_records =
 
 inline std::string const example_from_spec_header =
   R"(##fileformat=VCFv4.3
-##fileDate=20090805
+##fileDate=2022-03-02 14:18:22
 ##source=myImputationProgramV3.1
 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
@@ -55,6 +55,7 @@ inline std::string const example_from_spec = example_from_spec_header + example_
 
 inline std::string const example_from_spec_header_regenerated =
   R"(##fileformat=VCFv4.3
+##fileDate=2022-03-02 14:18:22
 ##FILTER=<ID=PASS,Description="All filters passed",IDX=0>
 ##FILTER=<ID=q10,Description="Quality below 10",IDX=7>
 ##FILTER=<ID=s50,Description="Less than 50% of samples have data",IDX=8>
@@ -69,7 +70,6 @@ inline std::string const example_from_spec_header_regenerated =
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth",IDX=2>
 ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality",IDX=11>
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x,IDX=0>
-##fileDate=20090805
 ##source=myImputationProgramV3.1
 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 ##phasing=partial
@@ -78,6 +78,7 @@ inline std::string const example_from_spec_header_regenerated =
 
 inline std::string const example_from_spec_header_regenerated_no_IDX =
   R"(##fileformat=VCFv4.3
+##fileDate=2022-03-02 14:18:22
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##FILTER=<ID=q10,Description="Quality below 10">
 ##FILTER=<ID=s50,Description="Less than 50% of samples have data">
@@ -92,7 +93,6 @@ inline std::string const example_from_spec_header_regenerated_no_IDX =
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
 ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
-##fileDate=20090805
 ##source=myImputationProgramV3.1
 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 ##phasing=partial
@@ -165,10 +165,10 @@ inline std::string const minimal_field_rows =
 
 inline std::string const incomplete_header_before =
   R"(##fileformat=VCFv4.3
+##fileDate=2022-03-02 14:18:22
 ##FILTER=<ID=PASS,Description="All filters passed",IDX=0>
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data",IDX=1>
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype",IDX=2>
-##fileDate=20090805
 ##source=myImputationProgramV3.1
 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 ##phasing=partial
@@ -177,6 +177,7 @@ inline std::string const incomplete_header_before =
 
 inline std::string const incomplete_header_after =
   R"(##fileformat=VCFv4.3
+##fileDate=2022-03-02 14:18:22
 ##FILTER=<ID=PASS,Description="All filters passed",IDX=0>
 ##FILTER=<ID=q10,Description="Automatically added by SeqAn3.",IDX=9>
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data",IDX=1>
@@ -190,7 +191,6 @@ inline std::string const incomplete_header_after =
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth",IDX=3>
 ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype quality",IDX=8>
 ##contig=<ID=20,IDX=0>
-##fileDate=20090805
 ##source=myImputationProgramV3.1
 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 ##phasing=partial

--- a/test/unit/var_io/var_io_header_test.cpp
+++ b/test/unit/var_io/var_io_header_test.cpp
@@ -23,6 +23,7 @@ TEST(var_io_header, spec_from_text)
     bio::var_io::header hdr{example_from_spec_header};
 
     EXPECT_EQ(hdr.file_format, "VCFv4.3");
+    EXPECT_EQ(hdr.file_date, "2022-03-02 14:18:22");
 
     // filters
     ASSERT_EQ(hdr.filters.size(), 3);
@@ -143,8 +144,7 @@ TEST(var_io_header, spec_from_text)
     EXPECT_TRUE(*++it == (svpair{"taxonomy", "x"}));
 
     // other lines in header
-    std::vector<std::string_view> other_lines_cmp{"fileDate=20090805",
-                                                  "source=myImputationProgramV3.1",
+    std::vector<std::string_view> other_lines_cmp{"source=myImputationProgramV3.1",
                                                   "reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta",
                                                   "phasing=partial"};
     ASSERT_EQ(hdr.other_lines.size(), other_lines_cmp.size());


### PR DESCRIPTION
This PR is a suggestion to add the filedate to the vcf. I have not yet customized the bcf tests. (I also haven't figured out how yet).
There is no regulation about the format of the filedate, so I decided to use a readable format like `##fileDate=2022-03-02 14:18:22`.